### PR TITLE
ci: bump registry tag resource version

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -4,7 +4,7 @@ resource_types:
     type: registry-image
     source:
       repository: tlwr/registry-tag-resource
-      tag: 1593696431
+      tag: 6d98ababb33b88eb6d9a0d3d2824c3efe500c18b
 
 resources:
   - name: golang-img-tag


### PR DESCRIPTION
What
----

Bumps registry-tag resource version in CI pipeline

Why
---

Use the latest version of ruby and dependencies